### PR TITLE
Erase unnecessary import of EthAddr

### DIFF
--- a/pyretic/examples/simple_ui_firewall.py
+++ b/pyretic/examples/simple_ui_firewall.py
@@ -5,8 +5,6 @@
 # author: Joshua Reich  (jreich@cs.princeton.edu)                              #
 ################################################################################
 
-from pox.lib.addresses import EthAddr
-
 from pyretic.lib.corelib import *
 from pyretic.lib.std import *
 from pyretic.modules.mac_learner import mac_learner


### PR DESCRIPTION
Importing EthAddr from pox inside simple_ui_firewall.py is unnecessary, as the module isn't using EthAddr and very confusing, as there is one EthAddr defined by Pyretic, and importing and using the one from Pox instead won't work. The best thing to do is just erase the import.
